### PR TITLE
Change calculator

### DIFF
--- a/src/constants/availability/AvailableClass.ts
+++ b/src/constants/availability/AvailableClass.ts
@@ -110,6 +110,26 @@ export class AvailableSingleTimeEventsIsIn extends Available<allEventsNames> {
   }
 }
 
+export class AvailablePreviousDayContains extends Available<allEventsNames> {
+  operation: Operations = Operations.IsIn;
+  name: allEventsNames;
+
+  constructor(props: { name: allEventsNames; reverse?: boolean }) {
+    super(props);
+    this.name = props.name;
+
+    this.getLeft = this.getLeft.bind(this);
+  }
+
+  getLeft() {
+    return this.name;
+  }
+
+  getRight(props: AvailabilityProps) {
+    return props.previousDay.activities.map((a) => a.name);
+  }
+}
+
 export class AvailableTimesIsIn extends Available<Times> {
   operation: Operations = Operations.IsIn;
   times: Times[];
@@ -340,6 +360,7 @@ export class False_ extends AvailabilityArray {
 
 const availables = {
   AvailableSingleTimeEventsIsIn,
+  AvailablePreviousDayContains,
   AvailableLinkLevelGreater,
   AvailableLinkLevelEqual,
   AvailableLinkIsNewLevel,

--- a/src/constants/events/EventClass.tsx
+++ b/src/constants/events/EventClass.tsx
@@ -8,7 +8,14 @@ import {
 
 import { EventCard, WideEvent } from "@/components";
 
-import { allEventsNames, Categories, eventProps, Times, Event } from "./types";
+import {
+  upgradeResponse,
+  allEventsNames,
+  Categories,
+  eventProps,
+  Times,
+  Event,
+} from "./types";
 import React from "react";
 
 export class EventClass implements Event {
@@ -39,11 +46,11 @@ export class EventClass implements Event {
     this.label = this.label.bind(this);
   }
 
-  available(props: SocialLinkAvailableProps) {
+  available(props: SocialLinkAvailableProps): boolean {
     return this.availability.available.bind(this.availability)(props);
   }
 
-  upgrade(props: SocialLinkAvailableProps) {
+  upgrade(props: SocialLinkAvailableProps): upgradeResponse {
     const newStats: { [key in StatsNames]?: number } = {};
 
     this.stats

--- a/src/constants/events/stats/statsEventsCourage.tsx
+++ b/src/constants/events/stats/statsEventsCourage.tsx
@@ -3,16 +3,24 @@ import { DaysNames } from "@/constants/monthsNames";
 
 import {
   AvailableSingleTimeEventsIsIn,
+  AvailablePreviousDayContains,
   AvailableDaysNamesIsIn,
   AvailableStatGreater,
   AvailableDateGreater,
   AvailableTimesIsIn,
-  False_,
   And_,
 } from "@/constants/availability/AvailableClass";
 
-import { wilduckBigEaterChallengeEvent, StatsEvents } from "./statsClass";
-import { statsEventsCourageNames, Times, Event } from "../types";
+import {
+  wilduckBigEaterChallengeEvent,
+  StatsEvents,
+} from "@/constants/events/stats/statsClass";
+import {
+  statsEventsCourageNames,
+  SpecialEventsNames,
+  Times,
+  Event,
+} from "@/constants/events/types";
 
 export const statsEventsCourage: {
   [key in statsEventsCourageNames]: Event;
@@ -20,10 +28,12 @@ export const statsEventsCourage: {
   [statsEventsCourageNames.drinkMedicine]: new StatsEvents({
     stats: [new StatsRepresentation(StatsNames.Courage, 2)],
     name: statsEventsCourageNames.drinkMedicine,
-    availability: new False_(),
     place: "Nurse's Office",
     time: Times.AfterSchool,
     special: true,
+    availability: new And_([
+      new AvailablePreviousDayContains({ name: SpecialEventsNames.Tartarus }),
+    ]),
   }),
   [statsEventsCourageNames.sleepDuringClass]: new StatsEvents({
     stats: [new StatsRepresentation(StatsNames.Courage, 2)],

--- a/src/constants/socialLinks/types.ts
+++ b/src/constants/socialLinks/types.ts
@@ -91,6 +91,7 @@ export type LinkDetailsType = {
 };
 
 export type SocialLinkAvailableProps = {
+  previousWeek?: SingleDay;
   previousDay?: SingleDay;
   currentDay: SingleDay;
   time: Times;


### PR DESCRIPTION
## Rework calendar calculation
- Every day calculate separately and subsequently
- Every event checked availability on a fly
- Remove filtering events for import process
- Much easier to push events ad hock
- Add `availability` to the `drinkMedicine` event
- Update types for `EventClass` methods