### PR TITLE
Development

### DIFF
--- a/src/constants/calendar/april.tsx
+++ b/src/constants/calendar/april.tsx
@@ -53,8 +53,9 @@ export const april: SingleDay[] = [
     activities: [
       events[statsEventsAcademicsNames.stayAwakeInClass],
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard head="Magician Boss Fight" />

--- a/src/constants/calendar/august.tsx
+++ b/src/constants/calendar/august.tsx
@@ -81,8 +81,9 @@ export const august: SingleDay[] = [
     isDayOff: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard head="Chariot and Justice Boss Fight" place="Tartarus" />

--- a/src/constants/calendar/august.tsx
+++ b/src/constants/calendar/august.tsx
@@ -27,7 +27,7 @@ export const august: SingleDay[] = [
         ...events[SpecialEventsNames.Special],
         label: () => <EventCard head="Running competitions" />,
       },
-      events[SocialLinkNames.Tower],
+      events[statsEventsAcademicsNames.wakatsuKitchenSpecial],
     ],
   }),
   new SingleDay({

--- a/src/constants/calendar/august.tsx
+++ b/src/constants/calendar/august.tsx
@@ -51,9 +51,6 @@ export const august: SingleDay[] = [
                 <p>Have {SocialLinkNames.Star} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.HangedMan} card</p>
-              </li>
-              <li>
                 <p>Have {SocialLinkNames.Hierophant} card</p>
               </li>
             </ul>

--- a/src/constants/calendar/january.tsx
+++ b/src/constants/calendar/january.tsx
@@ -267,8 +267,9 @@ export const january: SingleDay[] = [
     isDayOff: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard head="Nyx Boss Fight" place="Tartarus" />

--- a/src/constants/calendar/july.tsx
+++ b/src/constants/calendar/july.tsx
@@ -505,7 +505,7 @@ export const july: SingleDay[] = [
         ...events[SpecialEventsNames.Special],
         label: () => <EventCard head="Training for running competitions" />,
       },
-      events[SocialLinkNames.Tower],
+      events[statsEventsAcademicsNames.wakatsuKitchenSpecial],
     ],
   }),
 ];

--- a/src/constants/calendar/july.tsx
+++ b/src/constants/calendar/july.tsx
@@ -89,8 +89,9 @@ export const july: SingleDay[] = [
     exams: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard

--- a/src/constants/calendar/june.tsx
+++ b/src/constants/calendar/june.tsx
@@ -67,8 +67,9 @@ export const june: SingleDay[] = [
     foolMoon: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard

--- a/src/constants/calendar/june.tsx
+++ b/src/constants/calendar/june.tsx
@@ -311,16 +311,16 @@ export const june: SingleDay[] = [
                 <p>Be at least level 10</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.Hermit} card</p>
+                <p>Have {SocialLinkNames.Strength} card</p>
               </li>
               <li>
                 <p>Have {SocialLinkNames.Hierophant} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.HangedMan} card</p>
+                <p>Have {SocialLinkNames.Hermit} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.Strength} card</p>
+                <p>Have {SocialLinkNames.HangedMan} card</p>
               </li>
             </ul>
           </EventCard>

--- a/src/constants/calendar/may.tsx
+++ b/src/constants/calendar/may.tsx
@@ -127,10 +127,10 @@ export const may: SingleDay[] = [
                 <p>Have {SocialLinkNames.Chariot} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.Temperance} card</p>
+                <p>Have {SocialLinkNames.Justice} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.Justice} card</p>
+                <p>Have {SocialLinkNames.Temperance} card</p>
               </li>
               <li>
                 <p>Have {SocialLinkNames.Strength} card</p>

--- a/src/constants/calendar/may.tsx
+++ b/src/constants/calendar/may.tsx
@@ -96,8 +96,9 @@ export const may: SingleDay[] = [
     foolMoon: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => <EventCard head="Priestess Boss Fight" place="Tartarus" />,
       },
       { ...events[SocialLinkNames.Fool], time: Times.DarkHour },

--- a/src/constants/calendar/november.tsx
+++ b/src/constants/calendar/november.tsx
@@ -32,8 +32,9 @@ export const november: SingleDay[] = [
     foolMoon: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard
@@ -235,8 +236,9 @@ export const november: SingleDay[] = [
       events[SocialLinkNames.Sun],
       { ...events[SpecialEventsNames.DoNothing], time: Times.Evening },
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.DarkHour,
+        special: true,
         label: () => <EventCard head="Chidori Boss Fight" place="Tartarus" />,
       },
     ],

--- a/src/constants/calendar/november.tsx
+++ b/src/constants/calendar/november.tsx
@@ -306,7 +306,19 @@ export const november: SingleDay[] = [
     date: new Date(2009, 10, 28),
     activities: [
       events[SocialLinkNames.Priestess],
-      events[SpecialEventsNames.Tartarus],
+      {
+        ...events[SpecialEventsNames.Tartarus],
+        time: Times.Evening,
+        label: () => (
+          <EventCard head="Tartarus">
+            <ul>
+              <li>
+                <p>Have {SocialLinkNames.HangedMan} card</p>
+              </li>
+            </ul>
+          </EventCard>
+        ),
+      },
       events[SocialLinkNames.Fool],
     ],
   }),

--- a/src/constants/calendar/october.tsx
+++ b/src/constants/calendar/october.tsx
@@ -41,8 +41,9 @@ export const october: SingleDay[] = [
     isDayOff: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard

--- a/src/constants/calendar/october.tsx
+++ b/src/constants/calendar/october.tsx
@@ -24,7 +24,7 @@ export const october: SingleDay[] = [
     date: new Date(2009, 9, 2),
     activities: [
       events[SocialLinkNames.Priestess],
-      events[statsEventsAcademicsNames.wakatsuKitchenSpecial],
+      events[SocialLinkNames.Tower],
     ],
   }),
   new SingleDay({

--- a/src/constants/calendar/october.tsx
+++ b/src/constants/calendar/october.tsx
@@ -390,7 +390,22 @@ export const october: SingleDay[] = [
     activities: [
       events[statsEventsAcademicsNames.stayAwakeInClass],
       events[SocialLinkNames.Fortune],
-      events[SpecialEventsNames.Tartarus],
+      {
+        ...events[SpecialEventsNames.Tartarus],
+        time: Times.Evening,
+        label: () => (
+          <EventCard head="Tartarus">
+            <ul>
+              <li>
+                <p>Have {SocialLinkNames.Star} card</p>
+              </li>
+              <li>
+                <p>Have {SocialLinkNames.Strength} card</p>
+              </li>
+            </ul>
+          </EventCard>
+        ),
+      },
     ],
   }),
   new SingleDay({

--- a/src/constants/calendar/september.tsx
+++ b/src/constants/calendar/september.tsx
@@ -49,10 +49,10 @@ export const september: SingleDay[] = [
           <EventCard head="Tartarus">
             <ul>
               <li>
-                <p>Have {SocialLinkNames.Hermit} card</p>
+                <p>Have {SocialLinkNames.Justice} card</p>
               </li>
               <li>
-                <p>Have {SocialLinkNames.Justice} card</p>
+                <p>Have {SocialLinkNames.Hermit} card</p>
               </li>
             </ul>
           </EventCard>
@@ -272,9 +272,6 @@ export const september: SingleDay[] = [
           <EventCard head="Tartarus">
             <ul>
               <li>
-                <p>Have {SocialLinkNames.Lovers} card</p>
-              </li>
-              <li>
                 <p>Have {SocialLinkNames.Strength} card</p>
               </li>
               <li>
@@ -282,6 +279,12 @@ export const september: SingleDay[] = [
               </li>
               <li>
                 <p>Have {SocialLinkNames.Priestess} card</p>
+              </li>
+              <li>
+                <p>Have {SocialLinkNames.Justice} card</p>
+              </li>
+              <li>
+                <p>Have {SocialLinkNames.Lovers} card</p>
               </li>
             </ul>
           </EventCard>

--- a/src/constants/calendar/september.tsx
+++ b/src/constants/calendar/september.tsx
@@ -332,10 +332,7 @@ export const september: SingleDay[] = [
   new SingleDay({
     date: new Date(2009, 8, 27),
     isDayOff: true,
-    activities: [
-      events[SocialLinkNames.Sun],
-      events[statsEventsAcademicsNames.wakatsuKitchenSpecial],
-    ],
+    activities: [events[SocialLinkNames.Sun], events[SocialLinkNames.Tower]],
   }),
   new SingleDay({
     date: new Date(2009, 8, 28),

--- a/src/constants/calendar/september.tsx
+++ b/src/constants/calendar/september.tsx
@@ -72,8 +72,9 @@ export const september: SingleDay[] = [
     foolMoon: true,
     activities: [
       {
-        ...events[SpecialEventsNames.Special],
+        ...events[SpecialEventsNames.Tartarus],
         time: Times.WholeDay,
+        special: true,
         label: () => (
           <WideEvent>
             <EventCard head="Hermit Boss Fight" place="Tartarus" />

--- a/src/constants/events/specialEvents.tsx
+++ b/src/constants/events/specialEvents.tsx
@@ -47,6 +47,8 @@ export const specialEvents: { [key in SpecialEventsNames]: Event } = {
       new AvailableDateIsIn({
         reverse: true,
         date: [
+          new Date(2009, 3, 29),
+          new Date(2009, 4, 5),
           new Date(2009, 4, 16),
           new Date(2009, 4, 17),
           new Date(2009, 4, 25),

--- a/src/constants/events/stats/statsEventsCourage.tsx
+++ b/src/constants/events/stats/statsEventsCourage.tsx
@@ -133,7 +133,7 @@ export const statsEventsCourage: {
       name: statsEventsCourageNames.wilduckBigEaterChallenge,
       place: "Port Island Station",
       time: Times.Evening,
-      price: 1_500,
+      price: 1_800,
       stats: [
         new StatsRepresentation(StatsNames.Courage, 4),
         new StatsRepresentation(StatsNames.Charm, 4),

--- a/src/constants/socialLinks/Emperor.tsx
+++ b/src/constants/socialLinks/Emperor.tsx
@@ -42,7 +42,7 @@ class EmperorMainLevels extends LinkMainLevels {
         // checked
         points: 0,
         element: [
-          <Question label="Some students think the school uniform should be abolished, and they're recruiting supporters.">
+          <Question label="Some students think the school uniform should be abolished, and they're gathering supporters.">
             <Answer label="They've got a point." />
             <Answer label="Sounds like nonsense." points={15} />
           </Question>,


### PR DESCRIPTION
- Fix `wilduckBigEaterChallenge` event price
- Update `Emperor` link
- Update `Tartarus` event
- Move `Tower` link to the later time
- Update cards from `Tartarus`
- Make boss fight `Tartarus` instead of `Special`, to correctly apply `drink medicine` event